### PR TITLE
Application-Insights-based Diagnostics Service

### DIFF
--- a/Services.Test/DiagnosticsClientTest.cs
+++ b/Services.Test/DiagnosticsClientTest.cs
@@ -37,47 +37,6 @@ namespace Services.Test.External
         }
 
         [Fact]
-        public void ItReturnsTrueOnSucceess()
-        {
-            // Arrange
-            var response = new HttpResponse();
-
-            DiagnosticsClient target = new DiagnosticsClient(
-                this.mockHttpClient.Object,
-                new ServicesConfig
-                {
-                    DiagnosticsEndpointUrl = DIAGNOSTICS_SERVICE_URL
-                },
-                this.mockLogger.Object);
-
-            this.mockHttpClient
-                .Setup(x => x.PostAsync(It.IsAny<IHttpRequest>()))
-                .ReturnsAsync(response);
-
-            // Act
-            var result = target.SendAsync(JsonConvert.SerializeObject(this.data)).Result;
-
-            // Assert
-            Assert.False(result);
-        }
-
-        [Fact]
-        public void ItReturnsFalseOnEmptyDiagnosticsEndpointUrl()
-        {
-            // Arrange
-            DiagnosticsClient target = new DiagnosticsClient(
-                this.mockHttpClient.Object,
-                new ServicesConfig(),
-                this.mockLogger.Object);
-
-            // Act
-            var result = target.SendAsync(JsonConvert.SerializeObject(this.data)).Result;
-
-            // Assert
-            Assert.False(result);
-        }
-
-        [Fact]
         public void ItShouldReturnTrueIfUserConsentWasSuccessfullyRetrieved()
         {
             // Arrange
@@ -120,7 +79,7 @@ namespace Services.Test.External
             this.mockHttpClient
                 .Setup(x => x.GetAsync(It.IsAny<IHttpRequest>()))
                 .ThrowsAsync(new Exception());
-            
+
             // Act
             var result = target.CheckUserConsentAsync().Result;
 

--- a/Services.Test/DiagnosticsEventsServiceTest.cs
+++ b/Services.Test/DiagnosticsEventsServiceTest.cs
@@ -15,16 +15,16 @@ namespace Services.Test
     public class DiagnosticsEventsServiceTest
     {
         private const string DIAGNOSTICS_SERVICE_URL = @"http://diagnostics";
-        private readonly Mock<IDiagnosticsClient> diagnosticsClient;
-        private readonly Mock<IServicesConfig> servicesConfig;
+        private readonly Mock<IDiagnosticsClient> mockDiagnosticsClient;
+        private readonly Mock<IServicesConfig> mockServicesConfig;
         private readonly Mock<ITelemetryClientWrapper> mockTelemetryClientWrapper;
         private readonly DiagnosticsEventsService target;
         private readonly DiagnosticsEventsServiceModel data;
 
         public DiagnosticsEventsServiceTest()
         {
-            this.diagnosticsClient = new Mock<IDiagnosticsClient>();
-            this.servicesConfig = new Mock<IServicesConfig>();
+            this.mockDiagnosticsClient = new Mock<IDiagnosticsClient>();
+            this.mockServicesConfig = new Mock<IServicesConfig>();
             this.mockTelemetryClientWrapper = new Mock<ITelemetryClientWrapper>();
             this.data = new DiagnosticsEventsServiceModel
             {
@@ -36,8 +36,8 @@ namespace Services.Test
             };
 
             this.target = new DiagnosticsEventsService(
-                this.diagnosticsClient.Object,
-                this.servicesConfig.Object,
+                this.mockDiagnosticsClient.Object,
+                this.mockServicesConfig.Object,
                 this.mockTelemetryClientWrapper.Object,
                 new Logger("UnitTest"));
         }
@@ -46,10 +46,7 @@ namespace Services.Test
         public void ItReturnsTrueOnSucceess()
         {
            // Arrange
-           this.diagnosticsClient
-                .Setup(x => x.SendAsync(It.IsAny<string>()))
-                .ReturnsAsync(true);
-            this.diagnosticsClient
+            this.mockDiagnosticsClient
                 .Setup(x => x.CheckUserConsentAsync())
                 .ReturnsAsync(true);
 
@@ -61,11 +58,11 @@ namespace Services.Test
         }
 
         [Fact]
-        public void ItReturnsFalseOnFailure()
+        public void ItReturnsFalseIfUserHasOptedOut()
         {
             // Arrange
-            this.diagnosticsClient
-                .Setup(x => x.SendAsync(It.IsAny<string>()))
+            this.mockDiagnosticsClient
+                .Setup(x => x.CheckUserConsentAsync())
                 .ReturnsAsync(false);
 
             // Act

--- a/Services.Test/DiagnosticsEventsServiceTest.cs
+++ b/Services.Test/DiagnosticsEventsServiceTest.cs
@@ -2,6 +2,7 @@
 
 using System;
 using Microsoft.Azure.IoTSolutions.Diagnostics.Services;
+using Microsoft.Azure.IoTSolutions.Diagnostics.Services.ApplicationInsights;
 using Microsoft.Azure.IoTSolutions.Diagnostics.Services.Diagnostics;
 using Microsoft.Azure.IoTSolutions.Diagnostics.Services.External;
 using Microsoft.Azure.IoTSolutions.Diagnostics.Services.Models;
@@ -16,6 +17,7 @@ namespace Services.Test
         private const string DIAGNOSTICS_SERVICE_URL = @"http://diagnostics";
         private readonly Mock<IDiagnosticsClient> diagnosticsClient;
         private readonly Mock<IServicesConfig> servicesConfig;
+        private readonly Mock<ITelemetryClientWrapper> mockTelemetryClientWrapper;
         private readonly DiagnosticsEventsService target;
         private readonly DiagnosticsEventsServiceModel data;
 
@@ -23,6 +25,7 @@ namespace Services.Test
         {
             this.diagnosticsClient = new Mock<IDiagnosticsClient>();
             this.servicesConfig = new Mock<IServicesConfig>();
+            this.mockTelemetryClientWrapper = new Mock<ITelemetryClientWrapper>();
             this.data = new DiagnosticsEventsServiceModel
             {
                 EventId = "MockEventId",
@@ -35,6 +38,7 @@ namespace Services.Test
             this.target = new DiagnosticsEventsService(
                 this.diagnosticsClient.Object,
                 this.servicesConfig.Object,
+                this.mockTelemetryClientWrapper.Object,
                 new Logger("UnitTest"));
         }
 

--- a/Services/ApplicationInsights/TelemetryClientWrapper.cs
+++ b/Services/ApplicationInsights/TelemetryClientWrapper.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.ApplicationInsights;
+using Microsoft.Azure.IoTSolutions.Diagnostics.Services.Models;
+using Microsoft.Azure.IoTSolutions.Diagnostics.Services.Runtime;
+
+namespace Microsoft.Azure.IoTSolutions.Diagnostics.Services.ApplicationInsights
+{
+    public interface ITelemetryClientWrapper
+    {
+        TelemetryClient CreateTelemetryClient(IServicesConfig config);
+
+        void SetSessionAndDeploymentId(
+            TelemetryClient telemetryClient,
+            AppInsightsDataModel dataModel);
+
+        void TrackEvent(TelemetryClient telemetryClient, AppInsightsDataModel dataModel);
+    }
+
+    public class TelemetryClientWrapper: ITelemetryClientWrapper
+    {
+        public TelemetryClient CreateTelemetryClient(IServicesConfig config)
+        {
+            return new TelemetryClient
+            {
+                InstrumentationKey = config.AppInsightsInstrumentationKey
+            };
+        }
+
+        public void SetSessionAndDeploymentId(
+            TelemetryClient telemetryClient,
+            AppInsightsDataModel dataModel)
+        {
+            telemetryClient.Context.Session.Id = dataModel.SessionId.ToString();
+            telemetryClient.Context.User.Id = dataModel.DeploymentId;
+        }
+
+        public void TrackEvent(TelemetryClient telemetryClient, AppInsightsDataModel dataModel)
+        {
+            telemetryClient.TrackEvent(dataModel.EventType, dataModel.EventProperties);
+        }
+    }
+}

--- a/Services/DiagnosticsEventsService.cs
+++ b/Services/DiagnosticsEventsService.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Azure.IoTSolutions.Diagnostics.Services
             DateTimeOffset now = DateTimeOffset.UtcNow;
             TimeSpan duration = now - lastPolled;
 
-            //if (userConsent == null || duration.TotalSeconds >= this.servicesConfig.UserConsentPollingIntervalSecs)
+            if (userConsent == null || duration.TotalSeconds >= this.servicesConfig.UserConsentPollingIntervalSecs)
             {
                 try
                 {
@@ -64,6 +64,8 @@ namespace Microsoft.Azure.IoTSolutions.Diagnostics.Services
                 var appInsightsModelData = AppInsightsDataModel.FromServiceModel(serviceModelData);
                 this.telemetryClientWrapper.SetSessionAndDeploymentId(telemetryClient, appInsightsModelData);
                 this.telemetryClientWrapper.TrackEvent(telemetryClient, appInsightsModelData);
+
+                return true;
             }
 
             return false;

--- a/Services/DiagnosticsEventsService.cs
+++ b/Services/DiagnosticsEventsService.cs
@@ -59,13 +59,21 @@ namespace Microsoft.Azure.IoTSolutions.Diagnostics.Services
 
             if (userConsent == true)
             {
-                // Call out to App Insights
-                TelemetryClient telemetryClient = this.telemetryClientWrapper.CreateTelemetryClient(this.servicesConfig);
-                var appInsightsModelData = AppInsightsDataModel.FromServiceModel(serviceModelData);
-                this.telemetryClientWrapper.SetSessionAndDeploymentId(telemetryClient, appInsightsModelData);
-                this.telemetryClientWrapper.TrackEvent(telemetryClient, appInsightsModelData);
+                try
+                {
+                    // Call out to App Insights
+                    TelemetryClient telemetryClient =
+                        this.telemetryClientWrapper.CreateTelemetryClient(this.servicesConfig);
+                    var appInsightsModelData = AppInsightsDataModel.FromServiceModel(serviceModelData);
+                    this.telemetryClientWrapper.SetSessionAndDeploymentId(telemetryClient, appInsightsModelData);
+                    this.telemetryClientWrapper.TrackEvent(telemetryClient, appInsightsModelData);
 
-                return true;
+                    return true;
+                }
+                catch (Exception e)
+                {
+                    this.log.Error(e.Message, () => { });
+                }
             }
 
             return false;

--- a/Services/DiagnosticsEventsService.cs
+++ b/Services/DiagnosticsEventsService.cs
@@ -3,6 +3,8 @@
 using System;
 using System.Net.Http;
 using System.Threading.Tasks;
+using Microsoft.ApplicationInsights;
+using Microsoft.Azure.IoTSolutions.Diagnostics.Services.ApplicationInsights;
 using Microsoft.Azure.IoTSolutions.Diagnostics.Services.Diagnostics;
 using Microsoft.Azure.IoTSolutions.Diagnostics.Services.External;
 using Microsoft.Azure.IoTSolutions.Diagnostics.Services.Models;
@@ -13,7 +15,7 @@ namespace Microsoft.Azure.IoTSolutions.Diagnostics.Services
 {
     public interface ILogDiagnostics
     {
-        Task<bool> LogEventsAsync(DiagnosticsEventsServiceModel data);
+        Task<bool> LogEventsAsync(DiagnosticsEventsServiceModel serviceModelData);
     }
 
     public class DiagnosticsEventsService : ILogDiagnostics
@@ -21,25 +23,28 @@ namespace Microsoft.Azure.IoTSolutions.Diagnostics.Services
         private readonly ILogger log;
         private readonly IDiagnosticsClient diagnosticsClient;
         private readonly IServicesConfig servicesConfig;
+        private readonly ITelemetryClientWrapper telemetryClientWrapper;
         private static DateTimeOffset lastPolled = DateTimeOffset.UtcNow;
         private static bool? userConsent = null;
 
         public DiagnosticsEventsService(
             IDiagnosticsClient diagnosticsClient,
             IServicesConfig servicesConfig,
+            ITelemetryClientWrapper telemetryClientWrapper,
             ILogger logger)
         {
             this.log = logger;
             this.diagnosticsClient = diagnosticsClient;
             this.servicesConfig = servicesConfig;
+            this.telemetryClientWrapper = telemetryClientWrapper;
         }
 
-        public async Task<bool> LogEventsAsync(DiagnosticsEventsServiceModel data)
+        public async Task<bool> LogEventsAsync(DiagnosticsEventsServiceModel serviceModelData)
         {
             DateTimeOffset now = DateTimeOffset.UtcNow;
             TimeSpan duration = now - lastPolled;
 
-            if (userConsent == null || duration.TotalSeconds >= this.servicesConfig.UserConsentPollingIntervalSecs)
+            //if (userConsent == null || duration.TotalSeconds >= this.servicesConfig.UserConsentPollingIntervalSecs)
             {
                 try
                 {
@@ -54,8 +59,11 @@ namespace Microsoft.Azure.IoTSolutions.Diagnostics.Services
 
             if (userConsent == true)
             {
-                string jsonData = JsonConvert.SerializeObject(data);
-                return await this.diagnosticsClient.SendAsync(jsonData);
+                // Call out to App Insights
+                TelemetryClient telemetryClient = this.telemetryClientWrapper.CreateTelemetryClient(this.servicesConfig);
+                var appInsightsModelData = AppInsightsDataModel.FromServiceModel(serviceModelData);
+                this.telemetryClientWrapper.SetSessionAndDeploymentId(telemetryClient, appInsightsModelData);
+                this.telemetryClientWrapper.TrackEvent(telemetryClient, appInsightsModelData);
             }
 
             return false;

--- a/Services/External/DiagnosticsClient.cs
+++ b/Services/External/DiagnosticsClient.cs
@@ -16,7 +16,6 @@ namespace Microsoft.Azure.IoTSolutions.Diagnostics.Services.External
 {
     public interface IDiagnosticsClient
     {
-        Task<bool> SendAsync(string data);
         Task<bool> CheckUserConsentAsync();
         Task<StatusResultServiceModel> PingConfigServiceAsync();
     }
@@ -66,24 +65,6 @@ namespace Microsoft.Azure.IoTSolutions.Diagnostics.Services.External
             }
 
             return result;
-        }
-
-        public async Task<bool> SendAsync(string data)
-        {
-            var endpointUrl = this.config.DiagnosticsEndpointUrl;
-
-            if (string.IsNullOrEmpty((endpointUrl)))
-            {
-                return false;
-            }
-
-            var request = new HttpRequest();
-            request.SetUriFromString(endpointUrl);
-            StringContent content = new StringContent(data, Encoding.UTF8, "application/json");
-            request.SetContent(content);
-            var response = await this.httpClient.PostAsync(request);
-
-            return response.IsSuccess;
         }
 
         public async Task<bool> CheckUserConsentAsync()

--- a/Services/External/DiagnosticsClient.cs
+++ b/Services/External/DiagnosticsClient.cs
@@ -18,7 +18,6 @@ namespace Microsoft.Azure.IoTSolutions.Diagnostics.Services.External
     {
         Task<bool> SendAsync(string data);
         Task<bool> CheckUserConsentAsync();
-        Task<StatusResultServiceModel> PingDiagnosticsEndpointAsync();
         Task<StatusResultServiceModel> PingConfigServiceAsync();
     }
 
@@ -35,36 +34,6 @@ namespace Microsoft.Azure.IoTSolutions.Diagnostics.Services.External
             this.logger = logger;
         }
 
-        public async Task<StatusResultServiceModel> PingDiagnosticsEndpointAsync()
-        {
-            var result = new StatusResultServiceModel(false, "Diagnostics Azure Function check failed");
-            var endpointUrl = this.config.DiagnosticsEndpointUrl;
-            string data = "Ping Diagnostics service";
-            try
-            {
-                var request = new HttpRequest();
-                request.SetUriFromString(endpointUrl);
-                StringContent content = new StringContent(data, Encoding.UTF8, "application/json");
-                request.SetContent(content);
-
-                var response = await this.httpClient.PostAsync(request);
-                if (response.IsError)
-                {
-                    result.Message = $"Status code: {response.StatusCode}; Response: {response.Content}";
-                }
-                else
-                {
-                    result.IsHealthy = true;
-                    result.Message = "Alive and Well!";
-                }
-            }
-            catch (Exception e)
-            {
-                this.logger.Error(result.Message, () => new { e });
-            }
-
-            return result;
-        }
 
         public async Task<StatusResultServiceModel> PingConfigServiceAsync()
         {

--- a/Services/Models/AppInsightsDataModel.cs
+++ b/Services/Models/AppInsightsDataModel.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Collections.Generic;
+
+namespace Microsoft.Azure.IoTSolutions.Diagnostics.Services.Models
+{
+    public class AppInsightsDataModel
+    {
+        public string EventType { get; set; }
+
+        public long? SessionId { get; set; }
+
+        public Dictionary<string, string> EventProperties { get; set; }
+
+        public string DeploymentId { get; set; }
+
+        public static AppInsightsDataModel FromServiceModel(DiagnosticsEventsServiceModel model)
+        {
+            AppInsightsDataModel result = new AppInsightsDataModel
+            {
+                EventProperties = new Dictionary<string, string>(),
+                EventType = model.EventType,
+                SessionId = model.SessionId,
+                DeploymentId = model.DeploymentId
+            };
+
+            if (model.EventProperties != null)
+            {
+                foreach (string key in model.EventProperties.Keys)
+                {
+                    object value = model.EventProperties[key];
+                    if (value != null && value.ToString().Length > 0)
+                    {
+                        result.EventProperties[key] = value.ToString();
+                    }
+                }
+            }
+
+            if (model.UserProperties != null)
+            {
+                foreach (string key in model.UserProperties.Keys)
+                {
+                    object value = model.UserProperties[key];
+                    if (value != null && value.ToString().Length > 0)
+                    {
+                        result.EventProperties[key] = value.ToString();
+                    }
+                }
+            }
+
+            return result;
+        }
+    }
+}

--- a/Services/Runtime/ServicesConfig.cs
+++ b/Services/Runtime/ServicesConfig.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Azure.IoTSolutions.Diagnostics.Services.Runtime
         string IoTHubName { get; }
         string CloudType { get; }
         string SolutionName { get; }
+        string AppInsightsInstrumentationKey { get; }
         int UserConsentPollingIntervalSecs { get; }
     }
 
@@ -25,6 +26,7 @@ namespace Microsoft.Azure.IoTSolutions.Diagnostics.Services.Runtime
         public string IoTHubName { get; set; }
         public string CloudType { get; set; }
         public string SolutionName { get; set; }
+        public string AppInsightsInstrumentationKey { get; set; }
         public int UserConsentPollingIntervalSecs { get; set; }
     }
 }

--- a/Services/Runtime/ServicesConfig.cs
+++ b/Services/Runtime/ServicesConfig.cs
@@ -4,7 +4,6 @@ namespace Microsoft.Azure.IoTSolutions.Diagnostics.Services.Runtime
 {
     public interface IServicesConfig
     {
-        string DiagnosticsEndpointUrl { get; }
         string PcsConfigUrl { get; }
         string SolutionType { get; }
         string DeploymentId { get; }
@@ -18,7 +17,6 @@ namespace Microsoft.Azure.IoTSolutions.Diagnostics.Services.Runtime
 
     public class ServicesConfig : IServicesConfig
     {
-        public string DiagnosticsEndpointUrl { get; set; }
         public string PcsConfigUrl { get; set; }
         public string SolutionType { get; set; }
         public string DeploymentId { get; set; }

--- a/Services/Services.csproj
+++ b/Services/Services.csproj
@@ -6,6 +6,10 @@
     <RootNamespace>Microsoft.Azure.IoTSolutions.Diagnostics.Services</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.8.1" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="ApplicationInsights\" />
   </ItemGroup>
 </Project>

--- a/Services/StatusService.cs
+++ b/Services/StatusService.cs
@@ -31,10 +31,6 @@ namespace Microsoft.Azure.IoTSolutions.Diagnostics.Services
             var result = new StatusServiceModel(true, "Alive and well!");
             var errors = new List<string>();
 
-            // Check access to Diagnostics Azure Function
-            var diagnosticsTuple = await this.diagnosticsClient.PingDiagnosticsEndpointAsync();
-            SetServiceStatus("DiagnosticsAzureFunction", diagnosticsTuple, result, errors);
-
             // Check access to Config
             // TODO: Circular dependency keeps calling this method indefinetely
             // var configTuple = await this.diagnosticsClient.pingConfigServiceAsync();
@@ -69,7 +65,7 @@ namespace Microsoft.Azure.IoTSolutions.Diagnostics.Services
                 errors.Add(dependencyName + " check failed");
                 result.Status.IsHealthy = false;
             }
-            
+
             result.Dependencies.Add(dependencyName, serviceResult);
         }
     }

--- a/WebService/Properties/launchSettings.json
+++ b/WebService/Properties/launchSettings.json
@@ -5,7 +5,6 @@
             "launchBrowser": false,
             "launchUrl": "http://localhost:9006/v1/status",
             "environmentVariables": {
-                "PCS_DIAGNOSTICS_ENDPOINT_URL": "${PCS_DIAGNOSTICS_ENDPOINT_URL}",
                 "PCS_SOLUTION_TYPE": "${PCS_SOLUTION_TYPE}",
                 "PCS_DEPLOYMENT_ID": "${PCS_DEPLOYMENT_ID}",
                 "PCS_AUTH_REQUIRED": "false",

--- a/WebService/Runtime/Config.cs
+++ b/WebService/Runtime/Config.cs
@@ -24,7 +24,6 @@ namespace Microsoft.Azure.IoTSolutions.Diagnostics.WebService.Runtime
     {
         private const string APPLICATION_KEY = "diagnostics:";
         private const string PortKey = APPLICATION_KEY + "webservice_port";
-        private const string DIAGNOSTICS_BACKEND_SERVICE_URI_KEY = APPLICATION_KEY + "endpoint_url";
         private const string PCS_CONFIG_URL = APPLICATION_KEY + "pcs_config_url";
         private const string PCS_SOLUTION_TYPE = APPLICATION_KEY + "solution_type";
         private const string PCS_DEPLOYMENT_ID = APPLICATION_KEY + "deployment_id";
@@ -62,7 +61,6 @@ namespace Microsoft.Azure.IoTSolutions.Diagnostics.WebService.Runtime
 
             this.ServicesConfig = new ServicesConfig
             {
-                DiagnosticsEndpointUrl = configData.GetString(DIAGNOSTICS_BACKEND_SERVICE_URI_KEY),
                 PcsConfigUrl = configData.GetString(PCS_CONFIG_URL),
                 SolutionType = configData.GetString(PCS_SOLUTION_TYPE),
                 DeploymentId = configData.GetString(PCS_DEPLOYMENT_ID),

--- a/WebService/Runtime/Config.cs
+++ b/WebService/Runtime/Config.cs
@@ -45,6 +45,8 @@ namespace Microsoft.Azure.IoTSolutions.Diagnostics.WebService.Runtime
         private const string JWT_AUDIENCE_KEY = JWT_KEY + "audience";
         private const string JWT_CLOCK_SKEW_KEY = JWT_KEY + "clock_skew_seconds";
 
+        private const string APPINSIGHTS_INSTRUMENTATION_KEY = APPLICATION_KEY + "appinsights_instrumentation_key";
+
         /// <summary>Web service listening port</summary>
         public int Port { get; }
 
@@ -68,7 +70,8 @@ namespace Microsoft.Azure.IoTSolutions.Diagnostics.WebService.Runtime
                 CloudType = configData.GetString(PCS_CLOUD_TYPE),
                 IoTHubName = configData.GetString(PCS_IOTHUB_NAME),
                 SolutionName = configData.GetString(PCS_SOLUTION_NAME),
-                UserConsentPollingIntervalSecs = configData.GetInt(USER_CONSENT_POLLING_INTERVAL_KEY, 300)
+                UserConsentPollingIntervalSecs = configData.GetInt(USER_CONSENT_POLLING_INTERVAL_KEY, 300),
+                AppInsightsInstrumentationKey = configData.GetString(APPINSIGHTS_INSTRUMENTATION_KEY)
             };
 
             this.ClientAuthConfig = new ClientAuthConfig

--- a/WebService/Startup.cs
+++ b/WebService/Startup.cs
@@ -37,6 +37,9 @@ namespace Microsoft.Azure.IoTSolutions.Diagnostics.WebService
             // Add controllers as services so they'll be resolved.
             services.AddMvc().AddControllersAsServices();
 
+            // Add Application Insights support
+            services.AddApplicationInsightsTelemetry();
+
             this.ApplicationContainer = DependencyResolution.Setup(services);
 
             // Create the IServiceProvider based on the container

--- a/WebService/WebService.csproj
+++ b/WebService/WebService.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Autofac" Version="4.6.2" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.1.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.5.1" />
     <PackageReference Include="Microsoft.AspNetCore" Version="2.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="2.0.0" />

--- a/WebService/appsettings.ini
+++ b/WebService/appsettings.ini
@@ -31,6 +31,9 @@ iothub_name = "${?PCS_IOTHUB_NAME}"
 ; Name of solution
 solution_name = "${?PCS_SOLUTION_NAME}"
 
+; Application Insights Instrumentation Key
+appinsights_instrumentation_key = "${?PCS_APPINSIGHTS_INSTRUMENTATIONKEY}"
+
 ; Polling Interval for retrieving user consent
 ; Default: 5 minutes
 user_consent_polling_interval_seconds = 300

--- a/WebService/appsettings.ini
+++ b/WebService/appsettings.ini
@@ -7,9 +7,6 @@ webservice_port = 9006
 ; assemblies, otherwise prepend "/" for absolute paths.
 some_folder_path = ./data/somefiles
 
-; Backend service endpoint where requests to log data will be sent.
-endpoint_url = "${?PCS_DIAGNOSTICS_ENDPOINT_URL}"
-
 ; Config url for verifying user consent to collect data
 pcs_config_url = "${PCS_CONFIG_URL}"
 

--- a/scripts/env-vars-setup
+++ b/scripts/env-vars-setup
@@ -13,10 +13,6 @@
 # Some settings are used to connect to an external dependency, e.g. backend diagnostics service
 # Depending on which settings and which dependencies are needed, edit the list of variables
 
-# Backend diagnostics service endpoint where requests to log data will be sent.
-# E.g https://<sample>.azurewebsites.net/<api>
-export PCS_DIAGNOSTICS_ENDPOINT_URL="Enter backend diagnostics service url here"
-
 # Type of solution. E.g DeviceSimulation, RemoteMonitoring, etc.
 export PCS_SOLUTION_TYPE="Enter solution type here"
 

--- a/scripts/env-vars-setup.cmd
+++ b/scripts/env-vars-setup.cmd
@@ -5,10 +5,6 @@
 :: Some settings are used to connect to an external dependency, e.g. backend diagnostics service
 :: Depending on which settings and which dependencies are needed, edit the list of variables
 
-:: Backend diagnostics service endpoint where requests to log data will be sent.
-:: E.g https://<sample>.azurewebsites.net/<api>
-SETX PCS_DIAGNOSTICS_ENDPOINT_URL "Enter backend diagnostics service url here"
-
 :: Type of solution. E.g DeviceSimulation, RemoteMonitoring, etc.
 SETX PCS_SOLUTION_TYPE "Enter solution type here"
 


### PR DESCRIPTION
This change hooks the diagnostics microservice up to Application Insights so that all diagnostics requests on a deployed solution will be routed to Application Insights directly, instead of to the custom diagnostics service. This change will not break the diagnostics API so callers will not need to make any changes with this change. 

There will be a corresponding change to CLI to introduce the new environment variable that this change requires. 

- [ ] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Breaking change (breaks backward compatibility)

**Checklist:**

- [x] All tests passed
- [x] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly

# Description and Motivation <!-- Information and Context so others can review your pull request -->

...
