### PR TITLE
Adding SolutionType to the list of parameters reported to Application…

### DIFF
--- a/Services/Models/AppInsightsDataModel.cs
+++ b/Services/Models/AppInsightsDataModel.cs
@@ -8,11 +8,13 @@ namespace Microsoft.Azure.IoTSolutions.Diagnostics.Services.Models
     {
         public string EventType { get; set; }
 
+        public string DeploymentId { get; set; }
+
+        public string SolutionType { get; set; }
+
         public long? SessionId { get; set; }
 
         public Dictionary<string, string> EventProperties { get; set; }
-
-        public string DeploymentId { get; set; }
 
         public static AppInsightsDataModel FromServiceModel(DiagnosticsEventsServiceModel model)
         {
@@ -21,7 +23,8 @@ namespace Microsoft.Azure.IoTSolutions.Diagnostics.Services.Models
                 EventProperties = new Dictionary<string, string>(),
                 EventType = model.EventType,
                 SessionId = model.SessionId,
-                DeploymentId = model.DeploymentId
+                DeploymentId = model.DeploymentId,
+                SolutionType = model.SolutionType
             };
 
             if (model.EventProperties != null)


### PR DESCRIPTION
I noticed that we're not sending the SolutionType parameters in our Application Insights diagnostics. This will be a problem for anyone that wants to query diagnostics information by deployment type (Remote Monitoring, Device Simulation, etc.). For the most part this should be a non-issue, as we support each deployment type using different Application Insights instrumentation keys, but I'd like to pass this parameter in case we ever consolidate diagnostics in to a single Application Insights resource in the future. 

# Change type <!-- [x] in all the boxes that apply -->

- [ ] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Breaking change (breaks backward compatibility)

**Checklist:**

- [x] All tests passed
- [x] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly

# Description and Motivation <!-- Information and Context so others can review your pull request -->

...
